### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+compiler:
+    - clang
+    - gcc
+install:
+    - sudo apt-get -qq update
+    - sudo apt-get -qq install -y xorg-dev libglu1-mesa-dev cmake
+script: cmake . && make


### PR DESCRIPTION
Travis CI provides free continuous integration for open source projects: https://travis-ci.org/

 - Add travis.yml and configuration script that invokes cmake
 - Add gcc and clang. Override script to prevent "make test" running

Example build running for this fork: https://travis-ci.org/andystanton/glew-cmake