### PR TITLE
Fix cmake error on Linux "no LIBRARY DESTINATION" 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,8 @@ IF ( glew-cmake_BUILD_SHARED )
 		TARGET_INCLUDE_DIRECTORIES( libglew_shared PUBLIC ${INCLUDE_DIR} )
 		TARGET_LINK_LIBRARIES( libglew_shared ${GL_LIBRARY} ${PLATFORM_SPECIFIC_LIBRARIES} )
 		INSTALL( TARGETS libglew_shared ARCHIVE DESTINATION lib
-						RUNTIME DESTINATION bin)
+		                                LIBRARY DESTINATION lib
+		                                RUNTIME DESTINATION bin )
 	ENDIF (  )
 
 	IF ( glew-cmake_BUILD_MULTI_CONTEXT )
@@ -92,7 +93,8 @@ IF ( glew-cmake_BUILD_SHARED )
 		TARGET_INCLUDE_DIRECTORIES( libglewmx_shared PUBLIC ${INCLUDE_DIR} )
 		TARGET_LINK_LIBRARIES( libglewmx_shared ${GL_LIBRARY} ${PLATFORM_SPECIFIC_LIBRARIES} )
 		INSTALL( TARGETS libglewmx_shared ARCHIVE DESTINATION lib
-						  RUNTIME DESTINATION bin )
+		                                  LIBRARY DESTINATION lib
+		                                  RUNTIME DESTINATION bin )
 	ENDIF (  )
 ENDIF (  )
 


### PR DESCRIPTION
On Linux, cmake gives the error:
~~~bash
CMake Error at CMakeLists.txt:79 (INSTALL):
INSTALL TARGETS given no LIBRARY DESTINATION for shared library target
"libglew_shared".

CMake Error at CMakeLists.txt:94 (INSTALL):
INSTALL TARGETS given no LIBRARY DESTINATION for shared library target
"libglewmx_shared".

-- Configuring incomplete, errors occurred!
~~~

This bug was caused by the merge:
e4de8a77a1f91aa99088187c7b8f7ff6bd6d107c

Containing:
* Update library install directories in Cmake
  commit 5a7232fc53496fe667d53fc9c98206b644befd12

* Install directories set in single statement
  commit def19e7de4b34e6182e8f346cd14952424c574aa

The cause is that RUNTIME DESTINATION is now defined (for Windows), but
not LIBRARY DESTINATION (for Linux).

See issue:
https://github.com/Perlmint/glew-cmake/issues/17