### PR TITLE
Define GLEW_BUILD only for libglew_shared and not consumer targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(glew-cmake_BUILD_SHARED)
 		OUTPUT_NAME "glew"
 		DEBUG_POSTFIX d)
 
-	target_compile_definitions(libglew_shared PUBLIC GLEW_BUILD ${DEFINITIONS})
+	target_compile_definitions(libglew_shared PRIVATE GLEW_BUILD ${DEFINITIONS})
 	target_include_directories(libglew_shared PUBLIC ${INCLUDE_DIR})
 	target_link_libraries(libglew_shared ${LIBRARIES})
 	set_target_properties(libglew_shared PROPERTIES VERSION ${GLEW_VERSION})


### PR DESCRIPTION
Hello, thank you for maintaining this fork! It's a big help for CMake users like myself.

The issue I'm addressing affects CMake users who consume glew using the [add_subdirectory](https://cmake.org/cmake/help/v3.0/command/add_subdirectory.html) or [FetchContent](https://cmake.org/cmake/help/v3.11/module/FetchContent.html) API's. Those API's create a single project/solution with _all targets_ (that is, glew _and_ a users targets together). When they're all together in the same solution, CMake will define `GLEW_BUILD` for each target that links with glew. This is a problem because if `GLEW_BUILD` is defined, then `glew.h` will declare `GLEWAPI` as `__declspec(dllexport)` instead of `__declspec(dllimport)`  which causes linker errors for consumers.


The solution is to use `PRIVATE` instead of `PUBLIC` when defining `GLEW_BUILD`. The documentation for [target_compiler_definitions](https://cmake.org/cmake/help/v3.18/command/target_compile_definitions.html) does a poor job of explaining it, but [this discussion](https://stackoverflow.com/questions/30546677/cmake-how-to-set-multiple-compile-definitions-for-target-executable#comment49166048_30546748) clears it up. Basically, using `PUBLIC` defines the definition for the target you specify _and_ for all targets linking against it whereas `PRIVATE` only defines the definition for the specified target.  I believe `GLEW_BUILD` should only be defined for `libglew_shared`.