### PR TITLE
Fixing test fs case sensitivity garbage files in the source dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ else()
 endif()
 
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_fs_support_case_sensitivity
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_fs_support_case_sensitivity
 	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_fs_support_CASE_sensitivity)
 file(GLOB TEST_FILE_LIST ${CMAKE_BINARY_DIR}/test_fs_support_*_sensitivity)
 list(LENGTH TEST_FILE_LIST TEST_FILE_COUNT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,8 +159,8 @@ else()
 endif()
 
 execute_process(
-	COMMAND ${CMAKE_COMMAND} -E touch test_fs_support_case_sensitivity
-	COMMAND ${CMAKE_COMMAND} -E touch test_fs_support_CASE_sensitivity)
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_fs_support_case_sensitivity
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_fs_support_CASE_sensitivity)
 file(GLOB TEST_FILE_LIST ${CMAKE_BINARY_DIR}/test_fs_support_*_sensitivity)
 list(LENGTH TEST_FILE_LIST TEST_FILE_COUNT)
 if(TEST_FILE_COUNT EQUAL 2)


### PR DESCRIPTION
Fixing test fs case sensitivity minor issue where files where not created in the CMAKE_BINARY_DIR.
Maybe even the files should be deleted after created.